### PR TITLE
WIP: Update to JavaFX Plugin 0.0.9-SNAPSHOT & Module Plugin 1.6.0

### DIFF
--- a/airgapfx/build.gradle
+++ b/airgapfx/build.gradle
@@ -3,8 +3,7 @@ plugins {
     id 'java-library'
     id 'maven'
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
-    id 'org.javamodularity.moduleplugin' version "1.5.0"
+    id 'org.openjfx.javafxplugin' version '0.0.9'
 }
 
 sourceCompatibility = 9

--- a/airgaplib/build.gradle
+++ b/airgaplib/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'maven'
     id 'eclipse'
-    id 'org.javamodularity.moduleplugin'    version "1.5.0"
+    id 'org.javamodularity.moduleplugin' version "1.7.0"
 }
 
 /**

--- a/consensusj-netwallet-fx/build.gradle
+++ b/consensusj-netwallet-fx/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'groovy'
     id 'application'
-    id 'org.openjfx.javafxplugin'           version '0.0.8'
+    id 'org.openjfx.javafxplugin'           version '0.0.9'
     id 'org.beryx.jlink'                    version '2.17.3'
 }
 

--- a/consensusj-signwallet-fx/build.gradle
+++ b/consensusj-signwallet-fx/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'groovy'
     id 'application'
-    id 'org.openjfx.javafxplugin'           version '0.0.8'
+    id 'org.openjfx.javafxplugin'           version '0.0.9'
     id 'org.beryx.jlink'                    version '2.17.3'
 }
 

--- a/omnij-wallet/build.gradle
+++ b/omnij-wallet/build.gradle
@@ -1,9 +1,8 @@
 plugins {
     id 'groovy'
     id 'application'
-    id 'org.openjfx.javafxplugin'           version '0.0.8'
+    id 'org.openjfx.javafxplugin'           version '0.0.9'
     id 'org.beryx.jlink'                    version '2.16.2'
-    id 'org.javamodularity.moduleplugin'    version "1.5.0"
 }
 
 sourceCompatibility = 11


### PR DESCRIPTION
JavaFX Plugin 0.0.8 doesn’t work with Module Plugin 1.6.0, so this
commit is a test to see if 0.0.9-SNAPSHOT works. Looks good! But we’ll
wait for 0.0.9 final before upgrading in `master`